### PR TITLE
Save changes as a diff of before and after

### DIFF
--- a/src/Services/ChangesHistoryService.php
+++ b/src/Services/ChangesHistoryService.php
@@ -58,11 +58,16 @@ class ChangesHistoryService
         $hiddenFields = $model->getHidden();
         $attributesChanges = collect();
 
-        foreach ($model->getChanges() as $key => $afterValue) {
+        $changes = $model->getChanges();
+        if (empty($changes)) {
+            $changes = array_diff_assoc($model->toArray(), $originalModel->toArray());
+        }
+
+        foreach ($changes as $key => $afterValue) {
             if (!in_array($key, $hiddenFields)) {
                 $change = [
                     'before' => $originalModel->$key,
-                    'after'  => $afterValue,
+                    'after' => $model->$key,
                 ];
             } else {
                 $change = [

--- a/tests/Unit/ChangesHistoryServiceTest.php
+++ b/tests/Unit/ChangesHistoryServiceTest.php
@@ -20,7 +20,16 @@ class ChangesHistoryServiceTest extends TestCase
 
         $this->assertEquals(Change::TYPE_CREATED, $change->change_type);
         $this->assertEquals(get_class($testModel), $change->model_type);
-        $this->assertEquals(collect(), $change->changes);
+        $this->assertEquals(collect([
+            'title' => [
+                'before' => null,
+                'after' => 'Test title'
+            ],
+            'body' => [
+                'before' => null,
+                'after' => 'Test body'
+            ]
+        ]), $change->changes);
         $this->assertNull($change->changer_type);
     }
 }


### PR DESCRIPTION
The attribute `changes` is not always filled after model changing, e.g. on update() with mass-assigning. In this case need to store changes as a diff of before and after statements.